### PR TITLE
using managedEnvironments@2022-06-01-preview

### DIFF
--- a/deploy/environment.bicep
+++ b/deploy/environment.bicep
@@ -25,12 +25,11 @@ resource appInsightsComponents 'Microsoft.Insights/components@2020-02-02' = {
   }
 }
 
-resource env 'Microsoft.Web/kubeEnvironments@2021-02-01' = {
+resource env 'Microsoft.App/managedEnvironments@2022-06-01-preview' = {
   name: '${baseName}env'
   location: location
   properties: {
-    type: 'managed'
-    internalLoadBalancerEnabled: false
+    internal: false
     appLogsConfiguration: {
       destination: 'log-analytics'
       logAnalyticsConfiguration: {


### PR DESCRIPTION
Microsoft.Web kubeEnvironments resource type has migrated to the Microsoft.App namespace. For the new resource type, see [Microsoft.App managedEnvironments](https://learn.microsoft.com/en-us/azure/templates/microsoft.app/managedenvironments). check [this](https://learn.microsoft.com/en-us/azure/templates/microsoft.app/managedenvironments?pivots=deployment-language-bicep)